### PR TITLE
[Task#2] Criação de endpoint para pesquisa por id

### DIFF
--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroController.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroController.java
@@ -1,20 +1,26 @@
 package br.com.brainweb.interview.core.features.hero;
 
+import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.net.URI;
+import java.util.Optional;
 import java.util.UUID;
 
 import static java.lang.String.format;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.http.ResponseEntity.created;
+import static org.springframework.http.ResponseEntity.notFound;
+import static org.springframework.http.ResponseEntity.ok;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +34,17 @@ public class HeroController {
                                        @RequestBody CreateHeroRequest createHeroRequest) {
         final UUID id = heroService.create(createHeroRequest);
         return created(URI.create(format("/api/v1/heroes/%s", id))).build();
+    }
+
+    @GetMapping(path = "/{id}")
+    public ResponseEntity<Hero> getById(@PathVariable("id") String id) {
+
+        Optional<Hero> optionalHero = heroService.getById(UUID.fromString(id));
+
+        if (optionalHero.isPresent()) {
+            return ok(optionalHero.get());
+        }
+
+        return notFound().build();
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRepository.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRepository.java
@@ -13,19 +13,35 @@ import java.util.UUID;
 public class HeroRepository {
 
     private static final String CREATE_HERO_QUERY = "INSERT INTO hero" +
-        " (name, race, power_stats_id)" +
-        " VALUES (:name, :race, :powerStatsId) RETURNING id";
+            " (name, race, power_stats_id)" +
+            " VALUES (:name, :race, :powerStatsId) RETURNING id";
+
+    private static final String FIND_HERO_BY_ID = "SELECT " +
+            "h.id, h.name, h.race, h.power_stats_id, h.enabled, h.created_at, h.updated_at " +
+            //"p.id, p.strength, p.agility, p.dexterity, p.intelligence, p.created_at, p.updated_at" +
+            "FROM hero h " +
+            "WHERE h.id =:id ";
 
     private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
 
     UUID create(Hero hero) {
         final Map<String, Object> params = Map.of("name", hero.getName(),
-            "race", hero.getRace().name(),
-            "powerStatsId", hero.getPowerStatsId());
+                "race", hero.getRace().name(),
+                "powerStatsId", hero.getPowerStatsId());
 
         return namedParameterJdbcTemplate.queryForObject(
-            CREATE_HERO_QUERY,
-            params,
-            UUID.class);
+                CREATE_HERO_QUERY,
+                params,
+                UUID.class);
+    }
+
+    Hero findById(UUID heroId) {
+        final Map<String, Object> params = Map.of("id", heroId);
+
+        return this.namedParameterJdbcTemplate.queryForObject(
+                FIND_HERO_BY_ID,
+                params,
+                new HeroRowMapper()
+        );
     }
 }

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRowMapper.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroRowMapper.java
@@ -1,0 +1,23 @@
+package br.com.brainweb.interview.core.features.hero;
+
+import br.com.brainweb.interview.model.Hero;
+import br.com.brainweb.interview.model.enums.Race;
+import org.springframework.jdbc.core.RowMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.UUID;
+
+
+public class HeroRowMapper implements RowMapper<Hero> {
+
+    @Override
+    public Hero mapRow(ResultSet rs, int i) throws SQLException {
+        return Hero.builder()
+                .id(UUID.fromString(rs.getString("id")))
+                .name(rs.getString("name"))
+                .race(Race.valueOf(rs.getString("race")))
+                .powerStatsId(UUID.fromString(rs.getString("power_stats_id")))
+                .build();
+    }
+}

--- a/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
+++ b/core/src/main/java/br/com/brainweb/interview/core/features/hero/HeroService.java
@@ -5,6 +5,7 @@ import br.com.brainweb.interview.model.Hero;
 import br.com.brainweb.interview.model.PowerStats;
 import br.com.brainweb.interview.model.request.CreateHeroRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,8 +22,16 @@ public class HeroService {
 
     @Transactional
     public UUID create(CreateHeroRequest createHeroRequest) {
-
         UUID poweStatsId = this.powerStatsService.create(new PowerStats(createHeroRequest));
         return heroRepository.create(new Hero(createHeroRequest, poweStatsId));
+    }
+
+    public Optional<Hero> getById(UUID id) {
+        try {
+            Hero hero = this.heroRepository.findById(id);
+            return Optional.of(hero);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
     }
 }


### PR DESCRIPTION
* Criada estrutura para prover suporte para a pesquisa de heroi por id.
* Repositórios usando o método queryForObject (faz mais sentido que
usar o query, pois sempre será devolvido um único resultado, ou nenhum
caso o id pesquisado inexista), tratamento de erros colocada na
camada de serviço. Deveria a camada de acesso a dados trabalhar com
Optional, ou a implementação usada é realmente a mais correta (delegar
isso à camada de serviço)?
* Houve uma dúvida em relação à melhor forma de fazer o retorno do dado,
se usando o objeto de negócio (como foi entregue) ou se entregar um
objeto de visualização (DTO, ou VO - View Object), com as info do heroi
abertas (e não o objeto aninhadas através do id de power stats); por
fim, como é um projeto pequeno, segui nessa segunda abordagem e
entreguei em conjunto um endpoint para pesquisa de power stats,
conferinfo a responsabilidade de montar o objeto de visualização para o
cliente.